### PR TITLE
Disable resize of Field Element in Entry Form

### DIFF
--- a/src/components/EntryForm.jsx
+++ b/src/components/EntryForm.jsx
@@ -410,6 +410,7 @@ const FormWrapper = styled.div`
 `
 
 const FieldElement = styled(Field)`
+  resize: none;
 `;
 
 const Fieldset = styled.fieldset`


### PR DESCRIPTION
Made to avoid breaking the interface when resizing a textarea.
Fixes #227