### PR TITLE
Fixed events requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,22 @@ have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 To be able to start development you'll need the following tools:
 
 - [git](https://www.git-scm.com/)
-- [Node.js](https://nodejs.org/) version 8.x
-- [Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://www.npmjs.com/package/npm) version 3.x
+- [Node.js](https://nodejs.org/) version 6.x
+- [npm](https://www.npmjs.com/package/npm) version 3.x or [Yarn](https://yarnpkg.com/en/docs/getting-started)
 - [OpenFairDB](https://github.com/slowtec/openfairdb)
 
 Now clone this repository:
 
-    git clone https://github.com/diglabby/mapa.git
+    git clone https://github.com/diglabby/mapa
 
 Go to the root of it and install all the dependencies:
 
-    cd mapa/
-    yarn install
-or 
-    
+    cd goodmap-old/
     npm install
+or 
+    yarn
     
-### OpenFairDB local development setup
+### Local development setup
 
 The easiest way to get a local setup running is by using the remote API of [OpenFairDB](https://github.com/slowtec/openfairdb).
 To do so change `src/constants/URLs.js` to
@@ -51,49 +50,33 @@ OFDB_API: {
 
 The alternative is to run OpenFairDB Server locally:
 
-#### Linux setup:
+####Linux setup:
 
 ``` sh
-wget https://github.com/slowtec/openfairdb/releases/download/v0.5.5/openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
-tar xzf openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
+wget https://download.ofdb.io/openfairdb-x86_64-linux-v0.3.1.tar.gz
+tar xzf openfairdb-x86_64-linux-v0.3.1.tar.gz
 ./openfairdb
 ```
-
-To actually get started you also need to add some [content](https://github.com/flosse/openfairdb/files/2511314/openfair.db.zip). (Save database, copy it to openfairdb directory, unzip and override the previous database).
-
-Change this file `webpack.config.babel.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/b5d967c752df4b2e138e30fdbeb7101b5354be1c). And `src/constants/URLs.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/57cb6aa7bfe590130b93ed1236b7bf88ee8dac1a)
-
-Launch OpenfairDB
-
-    RUST_LOG=info ROCKET_PORT=6767 DATABASE_URL=openfair.db ./openfairdb
-
-from 
-/path/to/openfairdb/ directory. 
-
 `openfairdb` should now be listening on port 6767.
 
-If both `openfairdb` and `mapa` app are running, but no entries are displayed in `mapa` and you have an `ECONNREFUSED` error in console, then you should do the following:
+To actually get started you also need to add some [content](https://github.com/flosse/openfairdb/files/2511314/openfair.db.zip). (Save database, copy it to local repository, unzip and override the previous database).
 
-1. Go to file `webpack.config.babel.js`.
-2. Change line 25 to this: ```target: "http://[::1]:6767",```
-3. Rerun the `mapa` app.
-
-#### Docker setup:
+####Docker setup:
 
 1. Clone the [openfairdb](https://github.com/slowtec/openfairdb) repo.
 2. Go to `openfairdb` folder: `cd ./openfairdb`
 3. Build image and run the container by commands from [openfairdb](https://github.com/slowtec/openfairdb#docker) repo
 4. `openfairdb` should now be listening on port 6767.
 
-### Get the web app running:
+Get the web app running:
 
 ``` sh
-    cd /path/to/mapa/
-    yarn start
+    cd /path/to/goodmap-old/
+    npm start
 ```
 or 
 ```
-    npm start
+    yarn start
 ```
 
 The web app is now listening on port 8080.

--- a/README.md
+++ b/README.md
@@ -17,22 +17,23 @@ have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 To be able to start development you'll need the following tools:
 
 - [git](https://www.git-scm.com/)
-- [Node.js](https://nodejs.org/) version 6.x
-- [npm](https://www.npmjs.com/package/npm) version 3.x or [Yarn](https://yarnpkg.com/en/docs/getting-started)
+- [Node.js](https://nodejs.org/) version 8.x
+- [Yarn](https://yarnpkg.com/en/docs/getting-started) or [npm](https://www.npmjs.com/package/npm) version 3.x
 - [OpenFairDB](https://github.com/slowtec/openfairdb)
 
 Now clone this repository:
 
-    git clone https://github.com/diglabby/mapa
+    git clone https://github.com/diglabby/mapa.git
 
 Go to the root of it and install all the dependencies:
 
-    cd goodmap-old/
-    npm install
+    cd mapa/
+    yarn install
 or 
-    yarn
     
-### Local development setup
+    npm install
+    
+### OpenFairDB local development setup
 
 The easiest way to get a local setup running is by using the remote API of [OpenFairDB](https://github.com/slowtec/openfairdb).
 To do so change `src/constants/URLs.js` to
@@ -50,33 +51,47 @@ OFDB_API: {
 
 The alternative is to run OpenFairDB Server locally:
 
-####Linux setup:
+#### Linux setup:
 
 ``` sh
-wget https://download.ofdb.io/openfairdb-x86_64-linux-v0.3.1.tar.gz
-tar xzf openfairdb-x86_64-linux-v0.3.1.tar.gz
+wget https://github.com/slowtec/openfairdb/releases/download/v0.5.5/openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
+tar xzf openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
 ./openfairdb
 ```
-`openfairdb` should now be listening on port 6767.
 
 To actually get started you also need to add some [content](https://github.com/flosse/openfairdb/files/2511314/openfair.db.zip). (Save database, copy it to local repository, unzip and override the previous database).
 
-####Docker setup:
+Change this file `webpack.config.babel.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/b5d967c752df4b2e138e30fdbeb7101b5354be1c). And `src/constants/URLs.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/57cb6aa7bfe590130b93ed1236b7bf88ee8dac1a)
+
+Launch OpenfairDB
+
+    RUST_LOG=info ROCKET_PORT=6767 DATABASE_URL=openfair.db ./openfairdb
+
+from 
+/path/to/mapa/ directory. Be sure openfair.db and openfairdb files should be in the mapa directory.
+
+`openfairdb` should now be listening on port 6767.
+
+1. Go to file `webpack.config.babel.js`.
+2. Change line 25 to this: ```target: "http://[::1]:6767",```
+3. Rerun the ``mapa`` app.
+
+#### Docker setup:
 
 1. Clone the [openfairdb](https://github.com/slowtec/openfairdb) repo.
 2. Go to `openfairdb` folder: `cd ./openfairdb`
 3. Build image and run the container by commands from [openfairdb](https://github.com/slowtec/openfairdb#docker) repo
 4. `openfairdb` should now be listening on port 6767.
 
-Get the web app running:
+### Get the web app running:
 
 ``` sh
-    cd /path/to/goodmap-old/
-    npm start
+    cd /path/to/mapa/
+    yarn start
 ```
 or 
 ```
-    yarn start
+    npm start
 ```
 
 The web app is now listening on port 8080.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ tar xzf openfairdb_v0.5.5.x86_64-unknown-linux-musl.tar.xz
 ./openfairdb
 ```
 
-To actually get started you also need to add some [content](https://github.com/flosse/openfairdb/files/2511314/openfair.db.zip). (Save database, copy it to local repository, unzip and override the previous database).
+To actually get started you also need to add some [content](https://github.com/flosse/openfairdb/files/2511314/openfair.db.zip). (Save database, copy it to openfairdb directory, unzip and override the previous database).
 
 Change this file `webpack.config.babel.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/b5d967c752df4b2e138e30fdbeb7101b5354be1c). And `src/constants/URLs.js` according to this [commit](https://github.com/kartevonmorgen/kartevonmorgen/pull/583/commits/57cb6aa7bfe590130b93ed1236b7bf88ee8dac1a)
 
@@ -68,13 +68,15 @@ Launch OpenfairDB
     RUST_LOG=info ROCKET_PORT=6767 DATABASE_URL=openfair.db ./openfairdb
 
 from 
-/path/to/mapa/ directory. 
+/path/to/openfairdb/ directory. 
 
 `openfairdb` should now be listening on port 6767.
 
+If both `openfairdb` and `mapa` app are running, but no entries are displayed in `mapa` and you have an `ECONNREFUSED` error in console, then you should do the following:
+
 1. Go to file `webpack.config.babel.js`.
 2. Change line 25 to this: ```target: "http://[::1]:6767",```
-3. Rerun the ``mapa`` app.
+3. Rerun the `mapa` app.
 
 #### Docker setup:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Launch OpenfairDB
     RUST_LOG=info ROCKET_PORT=6767 DATABASE_URL=openfair.db ./openfairdb
 
 from 
-/path/to/mapa/ directory. Be sure openfair.db and openfairdb files should be in the mapa directory.
+/path/to/mapa/ directory. 
 
 `openfairdb` should now be listening on port 6767.
 

--- a/src/Actions/server.js
+++ b/src/Actions/server.js
@@ -86,7 +86,7 @@ const Actions = {
               const date = new window.Date();
               date.setHours(0, 0, 0, 0);
 
-              WebAPI.searchEvents(tags, bbox, date.getTime(), null, (err, res) => {
+              WebAPI.searchEvents(tags, bbox, getMidnightUnixtime(Date.now() / 1000), null, (err, res) => {
                 dispatch({
                   type: T.SEARCH_RESULT_EVENTS,
                   payload: err || res,

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -23,7 +23,10 @@ import NavButton            from "./pure/NavButton";
 import SearchBar            from "./SearchBar"
 import ScrollableDiv        from "./pure/ScrollableDiv";
 
-const converDateToTimestamp = (date) => new window.Date(date).getTime();
+const convertDateToTimestamp = date => {
+    date = new Date(date);
+    return Math.trunc(date / 1000) - (date.getTimezoneOffset() * 60);
+};
 
 class Sidebar extends Component {
 
@@ -195,8 +198,8 @@ class Sidebar extends Component {
                   categories: [data.category],
                   image_url: data.image_url,
                   image_link_url: data.image_link_url,
-                  end: data.end && converDateToTimestamp(data.end),
-                  start: data.start && converDateToTimestamp(data.start),
+                  end: convertDateToTimestamp(data.end),
+                  start: convertDateToTimestamp(data.start),
                 }
               ))
             )}

--- a/src/components/pure/EventTimes.jsx
+++ b/src/components/pure/EventTimes.jsx
@@ -6,7 +6,7 @@ const TimesWrapper = styled.div`
   margin-top: 7px;
 `;
 
-const getHumanDate = (date) => new Date(date).toDateString();
+const getHumanDate = (date) => new Date(date*1000).toDateString();
 
 const EventTimes = ({ start, end }) => {
   return (


### PR DESCRIPTION
Fixed #382 . Now we use seconds like kvm instead of milliseconds for `GET event` and `POST event` requests.